### PR TITLE
Updated version test for Exec[install-packer]

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,8 +42,10 @@ class packer(
 
       if versioncmp($version, '0.7.0') >= 0 {
         $prefix = 'packer_'
+        $version_test = "test -x packer && packer version | grep '^Packer v${version}$'"
       } else {
         $prefix = ''
+        $version_test = "test -x packer && packer --version | grep '^Packer v${version}$'"
       }
 
       $packer_basename = inline_template(
@@ -74,7 +76,7 @@ class packer(
         path    => [$bin_dir, '/usr/bin', '/bin'],
         cwd     => $bin_dir,
         user    => 'root',
-        unless  => "test -x packer && packer --version | grep '^Packer v${version}$'",
+        unless  => $version_test,
         require => Sys::Fetch['download-packer'],
       }
     }


### PR DESCRIPTION
Updated version test to use packer version instead of packer —version
for releases >= 0.7.0